### PR TITLE
Changed peerDependencies into normal dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ The ESLint rules that applies to React Native project. Applies `base` ones plus 
 
 The ESLint rules that applies to web based project. Applies `base` ones plus specific rules for React.
 
+## Dependencies
+
+Contrary to the original Airbnb's ESLint modules, we do not use peer dependencies
+but we instead use normal dependencies.
+
+Indeed, in our specific case, having normal dependencies reduce the maintenance burden
+of specifying all the needed peer dependencies when adding a specific ESLint configuration.
+
+That's means that we simply need to depend on the right config project (mobile, node or
+web) to run ESLint.
+
+Of course, it could causes problem eventually, but we are ready to live with it.
+
 ## Contributing
 
 First, install dependencies using `bin/prepare` script that uses Yarn 

--- a/modules/base/CHANGELOG.md
+++ b/modules/base/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Breaking Changes
 
+ * Switched to normal dependencies instead of peer ones.
+
  * Updated to `ESLint 4.x` release line.
 
 #### Features

--- a/modules/base/README.md
+++ b/modules/base/README.md
@@ -9,11 +9,3 @@ This package provides Samsao's base JS .eslintrc as an extensible shared config.
 This project is not meant to be used directly. Use [eslint-config-samsao-mobile](../eslint-config-samsao-mobile),
 [eslint-config-samsao-node](../eslint-config-samsao-node) or
 [eslint-config-samsao-web](../eslint-config-samsao-web) depending on your target environment.
-
-## Improving this config
-
-Consider adding test cases if you're making complicated rules changes, like anything involving regexes.
-
-You can run tests with `yarn test`.
-
-You can make sure this module lints with itself using `yarn run lint`.

--- a/modules/base/package.json
+++ b/modules/base/package.json
@@ -29,14 +29,13 @@
   "engines": {
     "node": ">= 4"
   },
-  "peerDependencies": {
+  "dependencies": {
     "eslint": "^4.15.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-import": "^2.8.0"
   },
   "devDependencies": {
-    "eslint": "^4.15.0",
     "in-publish": "^2.0.0",
     "safe-publish-latest": "^1.1.1"
   }

--- a/modules/mobile/CHANGELOG.md
+++ b/modules/mobile/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Breaking Changes
 
+ * Switched to normal dependencies instead of peer ones.
+
  * Updated to `ESLint 4.x` release line.
 
 #### Features

--- a/modules/mobile/README.md
+++ b/modules/mobile/README.md
@@ -6,7 +6,31 @@ This package provides Samsao's mobile JS .eslintrc as an extensible shared confi
 
 ## Usage
 
-The default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires
+Add to your project and extend config in your ESLint configuration file:
+
+ 1. yarn add --dev eslint-config-samsao-mobile
+ 1. Add `'extends': 'samsao-mobile'` to your `.eslintrc` or `eslintrc.js` file.
+
+## Dependencies
+
+Contrary to the original Airbnb's ESLint modules, we do not use peer dependencies
+but we instead use normal dependencies.
+
+Indeed, in our specific case, having normal dependencies reduce the maintenance burden
+of specifying all the needed peer dependencies when adding a specific ESLint
+configuration to a project.
+
+That's means that we simply need to depend on the right config project (mobile, node or
+web) to enable and configure ESLint.
+
+Of course, potential conflict problems could arise eventually, but we are ready to
+live with it.
+
+### Pulled Dependencies
+
+The default export contains all of our ESLint rules, including ECMAScript 6+, React and
+React Native. It pulls:
+
   * `eslint`
   * `eslint-config-airbnb`
   * `eslint-config-airbnb-base`
@@ -19,17 +43,10 @@ The default export contains all of our ESLint rules, including ECMAScript 6+ and
   * `eslint-plugin-react`
   * `eslint-plugin-react-native`
 
-1. Install the correct versions of each package, which are listed by the command:
+To re-generate the list above, one can use:
 
-   ```sh
-   yarn info 'eslint-config-samsao-mobile' peerDependencies
-   ```
-
-   Linux/OSX users can run
-
-   ```sh
-   export PKG=eslint-config-samsao-mobile; \
-   npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs yarn add --dev "$PKG"
-   ```
-
-2. Add `'extends': 'samsao-mobile'` to your `.eslintrc` file.
+```sh
+npm info "eslint-config-samsao-mobile@latest" dependencies --json | \
+grep eslint | \
+command sed 's/[\{\},]//g ; s/: .*//g ; s/^ *"/ * `/g ; s/"/`/g'
+```

--- a/modules/mobile/package.json
+++ b/modules/mobile/package.json
@@ -29,7 +29,7 @@
   "engines": {
     "node": ">= 4"
   },
-  "peerDependencies": {
+  "dependencies": {
     "eslint": "^4.15.0",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-airbnb-base": "^12.1.0",
@@ -42,7 +42,6 @@
     "eslint-plugin-react-native": "^3.2.1"
   },
   "devDependencies": {
-    "eslint": "^4.15.0",
     "in-publish": "^2.0.0",
     "safe-publish-latest": "^1.1.1"
   }

--- a/modules/node/CHANGELOG.md
+++ b/modules/node/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Breaking Changes
 
+ * Switched to normal dependencies instead of peer ones.
+
  * Updated to `ESLint 4.x` release line.
 
 ## 1.0.0 (June 29, 2017)

--- a/modules/node/README.md
+++ b/modules/node/README.md
@@ -6,24 +6,40 @@ This package provides Samsao's Node .eslintrc as an extensible shared config.
 
 ## Usage
 
-The default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires
+Add to your project and extend config in your ESLint configuration file:
+
+ 1. yarn add --dev eslint-config-samsao-node
+ 1. Add `'extends': 'samsao-node'` to your `.eslintrc` or `eslintrc.js` file.
+
+## Dependencies
+
+Contrary to the original Airbnb's ESLint modules, we do not use peer dependencies
+but we instead use normal dependencies.
+
+Indeed, in our specific case, having normal dependencies reduce the maintenance burden
+of specifying all the needed peer dependencies when adding a specific ESLint
+configuration to a project.
+
+That's means that we simply need to depend on the right config project (mobile, node or
+web) to enable and configure ESLint.
+
+Of course, potential conflict problems could arise eventually, but we are ready to
+live with it.
+
+### Pulled Dependencies
+
+The default export contains all of our ESLint rules, including ECMAScript 6+. It pulls:
+
   * `eslint`
   * `eslint-config-airbnb-base`
   * `eslint-config-samsao-base`
   * `eslint-plugin-filenames`
   * `eslint-plugin-import`
 
-  1. Install the correct versions of each package, which are listed by the command:
+To re-generate the list above, one can use:
 
-     ```sh
-     yarn info 'eslint-config-samsao-node' peerDependencies
-     ```
-
-     Linux/OSX users can run
-
-     ```sh
-     export PKG=eslint-config-samsao-node; \
-     npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs yarn add --dev "$PKG"
-     ```
-
-  2. Add `'extends': 'samsao-node'` to your `.eslintrc` file.
+```sh
+npm info "eslint-config-samsao-node@latest" dependencies --json | \
+grep eslint | \
+command sed 's/[\{\},]//g ; s/: .*//g ; s/^ *"/ * `/g ; s/"/`/g'
+```

--- a/modules/node/package.json
+++ b/modules/node/package.json
@@ -29,7 +29,7 @@
   "engines": {
     "node": ">= 4"
   },
-  "peerDependencies": {
+  "dependencies": {
     "eslint": "^4.15.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-samsao-base": "^2.0.0",
@@ -37,7 +37,6 @@
     "eslint-plugin-import": "^2.8.0"
   },
   "devDependencies": {
-    "eslint": "^4.15.0",
     "in-publish": "^2.0.0",
     "safe-publish-latest": "^1.1.1"
   }

--- a/modules/web/CHANGELOG.md
+++ b/modules/web/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Breaking Changes
 
+ * Switched to normal dependencies instead of peer ones.
+
  * Updated to `ESLint 4.x` release line.
 
 #### Features

--- a/modules/web/README.md
+++ b/modules/web/README.md
@@ -6,7 +6,31 @@ This package provides Samsao's web JS .eslintrc as an extensible shared config.
 
 ## Usage
 
-The default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires
+Add to your project and extend config in your ESLint configuration file:
+
+ 1. yarn add --dev eslint-config-samsao-web
+ 1. Add `'extends': 'samsao-web'` to your `.eslintrc` or `eslintrc.js` file.
+
+## Dependencies
+
+Contrary to the original Airbnb's ESLint modules, we do not use peer dependencies
+but we instead use normal dependencies.
+
+Indeed, in our specific case, having normal dependencies reduce the maintenance burden
+of specifying all the needed peer dependencies when adding a specific ESLint
+configuration to a project.
+
+That's means that we simply need to depend on the right config project (mobile, node or
+web) to enable and configure ESLint.
+
+Of course, potential conflict problems could arise eventually, but we are ready to
+live with it.
+
+### Pulled Dependencies
+
+The default export contains all of our ESLint rules, including ECMAScript 6+ and React.
+It pulls:
+
   * `eslint`
   * `eslint-config-airbnb`
   * `eslint-config-airbnb-base`
@@ -16,17 +40,10 @@ The default export contains all of our ESLint rules, including ECMAScript 6+ and
   * `eslint-plugin-jsx-a11y`
   * `eslint-plugin-react`
 
-  1. Install the correct versions of each package, which are listed by the command:
+To re-generate the list above, one can use:
 
-     ```sh
-     yarn info 'eslint-config-samsao-web' peerDependencies
-     ```
-
-     Linux/OSX users can run
-
-     ```sh
-     export PKG=eslint-config-samsao-web; \
-     npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs yarn add --dev "$PKG"
-     ```
-
-  2. Add `'extends': 'samsao-web'` to your `.eslintrc` file.
+```sh
+npm info "eslint-config-samsao-web@latest" dependencies --json | \
+grep eslint | \
+command sed 's/[\{\},]//g ; s/: .*//g ; s/^ *"/ * `/g ; s/"/`/g'
+```

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -29,7 +29,7 @@
   "engines": {
     "node": ">= 4"
   },
-  "peerDependencies": {
+  "dependencies": {
     "eslint": "^4.15.0",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-airbnb-base": "^12.1.0",
@@ -40,7 +40,6 @@
     "eslint-plugin-react": "^7.5.1"
   },
   "devDependencies": {
-    "eslint": "^4.15.0",
     "in-publish": "^2.0.0",
     "safe-publish-latest": "^1.1.1"
   }


### PR DESCRIPTION
In our specific case, having normal dependencies reduce the maintenance
burden of specifying all the needed peer dependencies when adding a
specific ESLint configuration.

That's means that we simply need to depend on the right config project
(mobile, node or web) to run ESLint.

Of course, it could causes conflict problems eventually, but we are ready to
live with it.